### PR TITLE
fix: rebuild with correct base-href for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Mercado</title>
-  <base href="/">
+  <base href="https://zclt.github.io/MercApp/">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
Rebuild da pasta docs usando o script github-docs para corrigir o base-href de "/" para "https://zclt.github.io/MercApp/", resolvendo os erros 404 dos arquivos JS/CSS no GitHub Pages.